### PR TITLE
更新 claude-code-review.yml

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -39,7 +39,7 @@ jobs:
         uses: anthropics/claude-code-action@v1
         with:
           anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
-          github_token: ${{ secrets.GITHUB_TOKEN }}
+          
           allowed_non_write_users: '*'
           prompt: |
             REPO: ${{ github.repository }}


### PR DESCRIPTION
使用OICD Token来防止在PR中出现github-actions回复的情况